### PR TITLE
Fixing null check error

### DIFF
--- a/src/lib/ReflexContainer.js
+++ b/src/lib/ReflexContainer.js
@@ -355,9 +355,9 @@ export default class ReflexContainer extends React.Component {
     document.body.classList.remove('reflex-row-resize')
     document.body.classList.remove('reflex-col-resize')
 
-    const resizedRefs = this.elements.map(element => {
+    const resizedRefs = this.elements ? this.elements.map(element => {
       return element.ref
-    })
+    }) : [];
 
     const elements = this.children.filter(child => {
       return !ReflexSplitter.isA(child) &&


### PR DESCRIPTION
Fixing null check error
Seeing error from library when moving the splitter

ReflexContainer.js?95b3:89 Uncaught TypeError: Cannot read property 'map' of null
    at ReflexEvents.eval (ReflexContainer.js?95b3:89)
    at ReflexEvents.emit (ReflexEvents.js?3497:63)
    at HTMLDocument.eval (ReflexSplitter.js?a489:92)

Code arrangement
<ReflexContainer orientation="horizontal">
              <ReflexElement direction={1}>
               <div>Some  dummy div</div>
              </ReflexElement>
              <ReflexSplitter propagate={true} onStopResize={args => {
               // this is needed since the reflex element state doesn't contain updated value. Getting the size and update it on stop resizing
                this.setState({
                  dockSize: this.getSize()
                })
              } }/>
              <ReflexElement size={this.state.dockSize} direction={-1} minSize={DOCK_MIN_SIZE}>
               <DockView onMaximizeClicked={this.onMaximizeClicked} onMinimizeClicked={this.onMinimizeClicked}/>
              </ReflexElement>
            </ReflexContainer>